### PR TITLE
Add token parameter in the Checkout code step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # all history
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Get All Tags
         run: git fetch --tags -f


### PR DESCRIPTION
The deploy action fails due a lack of permissions in the "Checkout code" step.  
This should be solved by setting the `token` parameter with the `secrets.RELEASE_TOKEN` value.
